### PR TITLE
Proposed additions to code, a/c control, idle timing, etc

### DIFF
--- a/speeduino/auxiliaries.h
+++ b/speeduino/auxiliaries.h
@@ -5,6 +5,9 @@ void initialiseAuxPWM();
 void boostControl();
 void vvtControl();
 void initialiseFan();
+void ACControl();
+void CELcontrol();
+void vvlControl();
 
 #if defined(CORE_AVR)
   #define ENABLE_BOOST_TIMER()  TIMSK1 |= (1 << OCIE1A)

--- a/speeduino/corrections.h
+++ b/speeduino/corrections.h
@@ -19,6 +19,7 @@ static inline byte correctionBatVoltage() __attribute__((always_inline)); //Batt
 static inline byte correctionIATDensity() __attribute__((always_inline)); //Inlet temp density correction
 static inline byte correctionLaunch() __attribute__((always_inline)); //Launch control correction
 static inline bool correctionDFCO() __attribute__((always_inline)); //Decelleration fuel cutoff
+static inline byte correctionVVL()  __attribute__((always_inline)); //VVLCorrection
 
 int8_t correctionsIgn(int8_t advance);
 static inline int8_t correctionFixedTiming(int8_t);

--- a/speeduino/globals.h
+++ b/speeduino/globals.h
@@ -266,12 +266,22 @@ struct statuses {
   byte wueCorrection; //The amount of warmup enrichment currently being applied
   byte batCorrection; //The amount of battery voltage enrichment currently being applied
   byte iatCorrection; //The amount of inlet air temperature adjustment currently being applied
+  byte vvlCorrection; // Amount of fuel added due to VVL
   byte launchCorrection; //The amount of correction being applied if launch control is active
   byte flexCorrection; //Amount of correction being applied to compensate for ethanol content
   byte flexIgnCorrection; //Amount of additional advance being applied based on flex
   byte afrTarget;
   byte idleDuty;
   bool fanOn; //Whether or not the fan is turned on
+  bool ACOn; //whether AC is on
+  bool AcReq; // AC request
+  bool highIdleReq; //raises idle in open loop to evade stalling
+  byte highIdleCount = 0;// counts to wait for normal idle
+  bool DFCOwait; // waits to enable DFCO
+  byte DFCOcounter = 0;// counts cycles till dfco
+  boolean coolantPulse = false;
+  int coolantGauge;
+  bool vvlOn = false;
   volatile byte ethanolPct; //Ethanol reading (if enabled). 0 = No ethanol, 100 = pure ethanol. Eg E85 = 85.
   unsigned long TAEEndTime; //The target end time used whenever TAE is turned on
   volatile byte status1;
@@ -421,6 +431,7 @@ struct config2 {
   byte TrigEdge : 1;
   byte TrigSpeed : 1;
   byte IgInv : 1;
+
   byte TrigPattern : 5;
 
   byte TrigEdgeSec : 1;

--- a/speeduino/idle.ino
+++ b/speeduino/idle.ino
@@ -229,7 +229,9 @@ void idleControl()
       {
         //Standard running
         currentStatus.idleDuty = table2D_getValue(&iacPWMTable, currentStatus.coolant + CALIBRATION_TEMPERATURE_OFFSET); //All temps are offset by 40 degrees
-        if( currentStatus.idleDuty == 0 ) { disableIdle(); break; }
+		if (currentStatus.AcReq == true){ currentStatus.idleDuty = currentStatus.idleDuty + 9;}
+        if ((currentStatus.highIdleReq) && (currentStatus.idleDuty < 60)){ currentStatus.idleDuty = 60;}
+		if( currentStatus.idleDuty == 0 ) { disableIdle(); break; }
         enableIdle();
         idle_pwm_target_value = percentage(currentStatus.idleDuty, idle_pwm_max_count);
         currentStatus.idleLoad = currentStatus.idleDuty >> 1;

--- a/speeduino/sensors.ino
+++ b/speeduino/sensors.ino
@@ -270,3 +270,9 @@ void flexPulse()
  {
    ++flexCounter;
  }
+
+  void readACReq()
+ {
+  if ((digitalRead(26) == HIGH) && (digitalRead(28) == LOW)) {currentStatus.AcReq = true;} //pin 26 is AC Request, pin 28 is a combined pressure/temp signal that is high when the A/C compressor can be activated
+  else {currentStatus.AcReq = false;}
+ }

--- a/speeduino/timers.h
+++ b/speeduino/timers.h
@@ -23,6 +23,7 @@ volatile byte loop33ms;
 volatile byte loop66ms;
 volatile byte loop100ms;
 volatile byte loop250ms;
+volatile byte loopCLT; //used for software PWM on XRS pnp ECU
 volatile int loopSec;
 
 volatile unsigned int dwellLimit_uS;

--- a/speeduino/utils.ino
+++ b/speeduino/utils.ino
@@ -526,6 +526,12 @@ void setPinMapping(byte boardID)
   pinMode(pinStepperEnable, OUTPUT);
   pinMode(pinBoost, OUTPUT);
   pinMode(pinVVT_1, OUTPUT);
+  pinMode(37, OUTPUT); // primary fan
+  pinMode(49, OUTPUT); // aux 
+  pinMode(45, OUTPUT); //ac control
+  pinMode(53, OUTPUT); // CEL control
+  pinMode(6, OUTPUT); // VVL Control
+  pinMode(2, OUTPUT); // temp gauge control for XRS
 
   inj1_pin_port = portOutputRegister(digitalPinToPort(pinInjector1));
   inj1_pin_mask = digitalPinToBitMask(pinInjector1);
@@ -575,6 +581,8 @@ void setPinMapping(byte boardID)
       pinMode(pinCLT, INPUT);
       pinMode(pinBat, INPUT);
       pinMode(pinBaro, INPUT);
+	  pinMode(26, INPUT); // pin input for AC
+      pinMode(28, INPUT_PULLUP); // pin input for AC pressure check, only usable when pulls to ground on overpressure
     #endif
   #endif
   pinMode(pinTrigger, INPUT);


### PR DESCRIPTION
Proposed additions to code which include
-Tacho gauge sweeping on key on (very probably should be flagged as an option, makes car misfire if started while gauge is sweeping)
-Idle timing control - allows use of timing to increase torque on RPM drop, and A/C request
-A/C control - allows control of the A/C clutch using an A/C request input, compensates for compressor load through timing and idle valve, has conditions to check for on/off A/C pressure switches, need to add evap temp control too
- reduces dwell on WOT to allows better dwell control in idle and cruising, very crude but still worked great
-simple VVL control - activates VVL on an output at the set conditions, has a fuel correction for when lift activates
-CEL control - CEL lights on at 0RPM, and when TPS is under the minimum ADC or above maximum (not really, I just though about this), and activates at a set RPM to function as a shift light
-dual fan support - secondary cooling fan turns on 7 degrees after the main fan
-high idle request - holds idle valve at a given position for some time after RPMs drop to evade engine stalling
-DFCO wait - waits for 2 seconds before cutting fuel, for when going in and out of DFCO 